### PR TITLE
add Flatcar Container Linux command

### DIFF
--- a/distro.go
+++ b/distro.go
@@ -50,7 +50,8 @@ func getOS() string {
 
 // return an operating-system specific user management command to run
 func getOSCommands(flavour string) distroCommands {
-	switch strings.ToLower(flavour) {
+	f := strings.ToLower(flavour)
+	switch f {
 	case "centos:7", "centos:7.4", "centos:7.5", "centos:7.6":
 		return distroCommands{
 			addUser: func(username string, home string) ([]byte, error) {
@@ -135,8 +136,51 @@ func getOSCommands(flavour string) distroCommands {
 				return exec.Command(args[0], args[1:]...).CombinedOutput()
 			},
 		}
+	}
+
+	switch {
+	case strings.HasPrefix(f, "flatcar"), strings.HasPrefix(f, "flatcar:3510.3"):
+		return distroCommands{
+			addUser: func(username string, home string) ([]byte, error) {
+				args := []string{"useradd", "-m", "--home-dir", home, username}
+				return exec.Command(args[0], args[1:]...).CombinedOutput()
+			},
+			delUser: func(username string) ([]byte, error) {
+				pgrep := []string{"pgrep", "-l", "-u", username}
+				if processlist, _ := exec.Command(pgrep[0], pgrep[1:]...).CombinedOutput(); strings.TrimSpace(string(processlist)) != "" {
+					log.Printf("Found %s processes: %s", username, strings.TrimSpace(strings.Replace(string(processlist), "\n", " ", -1)))
+					pkill := []string{"pkill", "--signal", "9", "-e", "-u", username}
+					out, _ := exec.Command(pkill[0], pkill[1:]...).CombinedOutput()
+					if strings.TrimSpace(string(out)) != "" {
+						log.Printf("Killed %s processes: %s", username, strings.TrimSpace(strings.Replace(string(out), "\n", " ", -1)))
+					}
+				}
+				args := []string{"userdel", "--remove", "-f", username}
+				return exec.Command(args[0], args[1:]...).CombinedOutput()
+			},
+			changeShell: func(username string, shell string) ([]byte, error) {
+				args := []string{"usermod", "--shell", shell, username}
+				return exec.Command(args[0], args[1:]...).CombinedOutput()
+			},
+			changePassword: func(username string, password string) ([]byte, error) {
+				args := []string{"usermod", "--password", password, username}
+				return exec.Command(args[0], args[1:]...).CombinedOutput()
+			},
+			changeHomeDir: func(username string, home string) ([]byte, error) {
+				args := []string{"usermod", "--move-home", "--home", home, username}
+				return exec.Command(args[0], args[1:]...).CombinedOutput()
+			},
+			changeGroups: func(username string, groups string) ([]byte, error) {
+				args := []string{"usermod", "--groups", groups, username}
+				return exec.Command(args[0], args[1:]...).CombinedOutput()
+			},
+			changeComment: func(username string, comment string) ([]byte, error) {
+				args := []string{"usermod", "--comment", comment, username}
+				return exec.Command(args[0], args[1:]...).CombinedOutput()
+			},
+		}
 	default:
-		log.Fatalf("No config for operating system: %s", flavour)
+		log.Fatalf("No config for operating system: %s", f)
 	}
 	return distroCommands{}
 }


### PR DESCRIPTION
I am using a distro called Flatcar Container Linux [Flatcar Container Linux](https://www.flatcar.org/)

I added support Flatcar.
However, Flatcar's version numbering is a bit unique, so I've made it a separate split from CentOS and Ubuntu.
https://www.flatcar.org/releases#lts-release

```
$ cat /etc/os-release
NAME="Flatcar Container Linux by Kinvolk"
ID=flatcar
ID_LIKE=coreos
VERSION=3510.3.5
VERSION_ID=3510.3.5
BUILD_ID=2024-07-02-0638
SYSEXT_LEVEL=1.0
PRETTY_NAME="Flatcar Container Linux by Kinvolk 3510.3.5 (LTS 2023)"
ANSI_COLOR="38;5;75"
HOME_URL="https://flatcar.org/"
BUG_REPORT_URL="https://issues.flatcar.org"
FLATCAR_BOARD="amd64-usr"
CPE_NAME="cpe:2.3:o:flatcar-linux:flatcar_linux:3510.3.5:*:*:*:*:*:*:*"
```

I'll fix it if other fixes are better.
